### PR TITLE
Should gracefully handle missing dependencies. Fixes substack/factor-bundle#33

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function() {
         if (seen[mod.id]) return;
         seen[mod.id] = true;
         if (hasDeps(mod)) {
-          var deps = values(mod.deps).map(resolve);
+          var deps = values(mod.deps).map(resolve).filter(Boolean);
           deps.sort(cmp);
           deps.forEach(visit);
         }

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "jshint": "~2.3.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "./node_modules/.bin/mocha specs.js"
   },
   "repository": {
     "type": "git",
-    "url": "andreypopp/deps-topo-sort"
+    "url": "https://github.com/andreypopp/deps-topo-sort"
   },
   "keywords": [
     "dependency",

--- a/specs.js
+++ b/specs.js
@@ -53,4 +53,25 @@ describe('deps-topo-sort', function() {
       done();
     });
   });
+
+  it('handles missing dependencies', function(done) {
+    var g = asStream(
+      {
+        id: 'main.css',
+        deps: {'z.css': 'z.css'}
+      },
+      {
+        id: 'z.css',
+        deps: {'missing.css': 'missing.css'}
+      }
+    );
+
+    aggregate(g.pipe(sort()), function(err, result) {
+      if (err) return done(err);
+      assert.deepEqual(
+        result.map(function(mod) { return mod.id; }),
+        ["z.css", "main.css"]);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
If we can't look up a dependency, we should assume it's been exported
via some other means, rather than causing an exception.

This could be caused by Browserify's 'exclude' or if using `require`
with an exposed name.
