### PR TITLE
Remove unused var

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,10 +19,7 @@ module.exports = function() {
       if (isEmpty) return this.queue(null);
 
       var queue = this.queue.bind(this),
-          topLevel = values(index),
           seen = {};
-
-      topLevel.sort(cmp);
 
       function visit(mod) {
         if (seen[mod.id]) return;


### PR DESCRIPTION
`topLevel` was never actually used - it was just being sorted.
